### PR TITLE
change font family to `Helvetica, Arial, sans-serif`

### DIFF
--- a/design.css
+++ b/design.css
@@ -22,9 +22,9 @@ html[data-theme="light"],
   --cfg: black;
   --cbg: #fff;
   --ornament: "‹‹‹ ›››";
-  --font-p: 13pt Garamond, sans-serif;
-  --font-h: 13pt Garamond, sans-serif;
-  --font-c: 12pt Garamond, sans-serif;
+  --font-p: 13pt Helvetica, Arial, sans-serif;
+  --font-h: 13pt Helvetica, Arial, sans-serif;
+  --font-c: 12pt Helvetica, Arial, sans-serif;
 }
 
 /* 2. Reset & Base Tags


### PR DESCRIPTION
Fixes #9 

I have tested it on a Windows PC where it earlier showed a serif font. On Ubuntu (chrome) it falls back to Arial. On Ubuntu (firefox) it uses [Nimbus Sans](https://en.wikipedia.org/wiki/Nimbus_Sans) which is an alternative to Helvetica.