### PR TITLE
added ::after pseudoelement to external links, closes #22

### DIFF
--- a/93218339c23.css
+++ b/93218339c23.css
@@ -99,6 +99,9 @@ select:hover {
   color: white;
   border-color: var(--cemph);
 }
+a[target=_blank]::after {
+  content: "↗";
+}
 
 /* headings */
 h1,


### PR DESCRIPTION
Added a css rule to add a ::after pseudoelement with "↗" as content to all links with target="_blank" property.